### PR TITLE
Propagates errors on download stream

### DIFF
--- a/lib/download-stream.js
+++ b/lib/download-stream.js
@@ -16,6 +16,7 @@ module.exports = class DownloadStream extends Readable {
 
         downloader.on('error', function(err) {
             debug('downloader err: ' + err);
+            self.emit('error', err);
         });
 
         downloader.on('finish', function() {


### PR DESCRIPTION
@rquiz @melindalu @promiseofcake @negator This is the fix that made `s3-stream-download` propagate errors coming from S3.